### PR TITLE
Fixed PlayerControllerInstance being set to a non-controlled PlayerControllerB

### DIFF
--- a/SpectatorChat/Patch/HUD/KeyPatch.cs
+++ b/SpectatorChat/Patch/HUD/KeyPatch.cs
@@ -10,30 +10,28 @@ namespace SpectatorChat.Patch.HUD
     {
         internal static void Postfix(PlayerControllerB __instance)
         {
-            if (!__instance.IsOwner && !__instance.isTestingPlayer)
+            if ((__instance.IsOwner && (__instance.isPlayerControlled || __instance.isPlayerDead) && (!__instance.IsServer || __instance.isHostPlayerObject)) || __instance.isTestingPlayer)
             {
-                return;
-            }
-
-            if (GlobalVariables.PlayerControllerInstance != __instance || GlobalVariables.PlayerControllerInstance == null)
-            {
-                Plugin.mls.LogInfo($"Player instance has changed due to {GlobalVariables.PlayerControllerInstance != __instance} or {GlobalVariables.PlayerControllerInstance == null}");
-                GlobalVariables.PlayerControllerInstance = __instance;
-            }
-            
-            if (__instance.isPlayerDead)
-            {
-                if (Plugin.InputActionInstance.ToggleDeathBoxKey.WasPressedThisFrame())
+                if (GlobalVariables.PlayerControllerInstance != __instance || GlobalVariables.PlayerControllerInstance == null)
                 {
-                    if (!Plugin.KeyPressed)
+                    Plugin.mls.LogInfo($"Player instance has changed due to {GlobalVariables.PlayerControllerInstance != __instance} or {GlobalVariables.PlayerControllerInstance == null}");
+                    GlobalVariables.PlayerControllerInstance = __instance;
+                }
+                
+                if (__instance.isPlayerDead)
+                {
+                    if (Plugin.InputActionInstance.ToggleDeathBoxKey.WasPressedThisFrame())
                     {
-                        Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, false);
-                        Plugin.KeyPressed = true;
-                    }
-                    else
-                    {
-                        Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, true);
-                        Plugin.KeyPressed = false;
+                        if (!Plugin.KeyPressed)
+                        {
+                            Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, false);
+                            Plugin.KeyPressed = true;
+                        }
+                        else
+                        {
+                            Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, true);
+                            Plugin.KeyPressed = false;
+                        }
                     }
                 }
             }

--- a/SpectatorChat/Patch/HUD/KeyPatch.cs
+++ b/SpectatorChat/Patch/HUD/KeyPatch.cs
@@ -10,28 +10,30 @@ namespace SpectatorChat.Patch.HUD
     {
         internal static void Postfix(PlayerControllerB __instance)
         {
-            if ((__instance.IsOwner && (__instance.isPlayerControlled || __instance.isPlayerDead) && (!__instance.IsServer || __instance.isHostPlayerObject)) || __instance.isTestingPlayer)
+            if (!((__instance.IsOwner && (__instance.isPlayerControlled || __instance.isPlayerDead) && (!__instance.IsServer || __instance.isHostPlayerObject)) || __instance.isTestingPlayer))
             {
-                if (GlobalVariables.PlayerControllerInstance != __instance || GlobalVariables.PlayerControllerInstance == null)
+                return;
+            }
+
+            if (GlobalVariables.PlayerControllerInstance != __instance || GlobalVariables.PlayerControllerInstance == null)
+            {
+                Plugin.mls.LogInfo($"Player instance has changed due to {GlobalVariables.PlayerControllerInstance != __instance} or {GlobalVariables.PlayerControllerInstance == null}");
+                GlobalVariables.PlayerControllerInstance = __instance;
+            }
+            
+            if (__instance.isPlayerDead)
+            {
+                if (Plugin.InputActionInstance.ToggleDeathBoxKey.WasPressedThisFrame())
                 {
-                    Plugin.mls.LogInfo($"Player instance has changed due to {GlobalVariables.PlayerControllerInstance != __instance} or {GlobalVariables.PlayerControllerInstance == null}");
-                    GlobalVariables.PlayerControllerInstance = __instance;
-                }
-                
-                if (__instance.isPlayerDead)
-                {
-                    if (Plugin.InputActionInstance.ToggleDeathBoxKey.WasPressedThisFrame())
+                    if (!Plugin.KeyPressed)
                     {
-                        if (!Plugin.KeyPressed)
-                        {
-                            Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, false);
-                            Plugin.KeyPressed = true;
-                        }
-                        else
-                        {
-                            Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, true);
-                            Plugin.KeyPressed = false;
-                        }
+                        Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, false);
+                        Plugin.KeyPressed = true;
+                    }
+                    else
+                    {
+                        Generic.ToggleSpectatorBoxUI(GlobalVariables.HUDManagerInstance!, true);
+                        Plugin.KeyPressed = false;
                     }
                 }
             }


### PR DESCRIPTION
- Fixed log spam due to PlayerControllerInstance constantly being set to non-controlled player controllers